### PR TITLE
Add automated releases and download badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,35 @@
-on: [push, pull_request, workflow_dispatch]
+name: Build ZMK Firmware
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
     uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+
+  create_release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Create Release with firmware
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.date.outputs.date }}-${{ github.sha }}
+          name: Firmware ${{ steps.date.outputs.date }}
+          body: Build from commit ${{ github.sha }}
+          files: '*.uf2'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Sofle Hybrid Keyboard Firmware
+
+[![Build Status](../../actions/workflows/build.yml/badge.svg)](../../actions)
+[![Download Firmware](https://img.shields.io/badge/Download-Firmware-blue?logo=github)](../../releases/latest)
+
 # Rev 5 annoucement:
 We have created several version of pcb for this keyboard since it first started, but most of them are incremental changes and nothing breaks, but since May of 2025, we ship all of our Sofle hybrid keyboards with the rev5, this mark the end of the EVQ roller encoder and introducing the Roller encoder of our own. Due to this breaking changes, we update the repo and now the branch name `Default` are for the old pcb and the `sofle_hybrid_rgb_rev5` is for the rev5 pcb.
 # The Sofle hybrid is now fully supported by ZMK Studio

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Rev 5 annoucement:
+We have created several version of pcb for this keyboard since it first started, but most of them are incremental changes and nothing breaks, but since May of 2025, we ship all of our Sofle hybrid keyboards with the rev5, this mark the end of the EVQ roller encoder and introducing the Roller encoder of our own. Due to this breaking changes, we update the repo and now the branch name `Default` are for the old pcb and the `sofle_hybrid_rgb_rev5` is for the rev5 pcb.
 # The Sofle hybrid is now fully supported by ZMK Studio
 The sofle Hybrid now can work with zmk studio. 
 Here is how you can use it: visit https://zmk.studio/ using Edge or Chrome.


### PR DESCRIPTION
## Changes
This adds automated firmware releases and download badges to the README on push.

Each release uses the date and commit hash for clear naming. The README includes build status and download badges that work on any fork. Releases provide permanent firmware downloads that don't expire.